### PR TITLE
refactor: renew component register and cleanup

### DIFF
--- a/app/noco/page-templates/index.ts
+++ b/app/noco/page-templates/index.ts
@@ -1,8 +1,10 @@
-import { ComponentRegistryMap } from "noco-lib/editing/component-registry";
+import { ComponentDriver } from "noco-lib/editing/component-registry";
 
-export const pageTemplates: ComponentRegistryMap = new Map([
-  [
-    "defaultPageTemplate",
-    async () => (await import("./default-page-template")).DefaultPageTemplate,
-  ],
-]);
+export const pageTemplates: ComponentDriver[] = [
+  {
+    id: "pageTemplates/defaultPageTemplate",
+    type: "pageTemplate",
+    loadComponent: async () =>
+      (await import("./default-page-template")).DefaultPageTemplate,
+  },
+];

--- a/app/noco/sections/gallery.tsx
+++ b/app/noco/sections/gallery.tsx
@@ -1,18 +1,16 @@
-import React from 'react';
-
 export interface GalleryProps {
-    title: string;
-    /** @format image-url */
-    images: string[];
+  title: string;
+  /** @format image-url */
+  images: string[];
 }
 
 export const Gallery = (props: GalleryProps) => {
-    return (
-        <div>
-            <h1>{props.title}</h1>
-            {props.images.map((image) => (
-                <img key={image} src={image} alt="" />
-            ))}
-        </div>
-    );
+  return (
+    <div>
+      <h1>{props.title}</h1>
+      {props.images.map((image) => (
+        <img key={image} src={image} alt="" />
+      ))}
+    </div>
+  );
 };

--- a/app/noco/sections/hero.tsx
+++ b/app/noco/sections/hero.tsx
@@ -1,18 +1,16 @@
-import React from 'react';
-
 export interface HeroProps {
-    title: string;
-    subtitle: string;
-    /** @format image-url */
-    image: string;
+  title: string;
+  subtitle: string;
+  /** @format image-url */
+  image: string;
 }
 
 export const Hero = (props: HeroProps) => {
-    return (
-        <div>
-            <h1>{props.title}</h1>
-            <h2>{props.subtitle}</h2>
-            <img src={props.image} alt="" />
-        </div>
-    );
+  return (
+    <div>
+      <h1>{props.title}</h1>
+      <h2>{props.subtitle}</h2>
+      <img src={props.image} alt="" />
+    </div>
+  );
 };

--- a/app/noco/sections/index.tsx
+++ b/app/noco/sections/index.tsx
@@ -1,5 +1,14 @@
-import { ComponentRegistryMap } from "noco-lib/editing/component-registry";
+import { ComponentDriver } from "noco-lib/editing/component-registry";
 
-export const sectionMap: ComponentRegistryMap = new Map();
-sectionMap.set("hero", async () => (await import("./hero")).Hero);
-sectionMap.set("gallery", async () => (await import("./gallery")).Gallery);
+export const sections: ComponentDriver[] = [
+  {
+    id: "sections/hero",
+    type: "section",
+    loadComponent: async () => (await import("./hero")).Hero,
+  },
+  {
+    id: "sections/gallery",
+    type: "section",
+    loadComponent: async () => (await import("./gallery")).Gallery,
+  },
+];

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { ComponentRegistry } from "noco-lib/editing/component-registry";
-import { componentRegistryContext } from "noco-lib/editing/use-component";
+import { componentRegistryContext } from "noco-lib/editing/component-registry-context";
 import { pageTemplates } from "~/noco/page-templates";
-import { sectionMap } from "~/noco/sections";
+import { sections } from "~/noco/sections";
 import homeData from "../../data-mocks/home.json";
 import pageList from "../../data-mocks/page-list.json";
 import {
@@ -10,7 +10,7 @@ import {
 } from "noco-lib/editing/editing-data-manager";
 import { expandDataWithNewIds } from "noco-lib/universal/expander";
 import { ExpandedDataWithBlock } from "noco-lib/universal/types";
-import { NocoErrorViewFactory } from "noco-lib/editing/noco-error-view";
+import { systemErrors } from "noco-lib/editing/noco-error-view";
 export const meta = () => {
   return [
     { title: "New Remix App" },
@@ -18,19 +18,18 @@ export const meta = () => {
   ];
 };
 
-const componentRegistry = new ComponentRegistry(
-  NocoErrorViewFactory("ComponentRegistry", "Loading", true),
-  NocoErrorViewFactory("ComponentRegistry", "Loading", true)
-);
+const componentRegistry = new ComponentRegistry();
+componentRegistry.registerAll(systemErrors);
+componentRegistry.registerAll(pageTemplates);
+componentRegistry.registerAll(sections);
 
-componentRegistry.addRegistry("pageTemplates", pageTemplates);
-componentRegistry.addRegistry("sections", sectionMap);
 const fetchPageList = async () => expandDataWithNewIds(pageList);
 const fetchPage = async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data = homeData as any;
   return expandDataWithNewIds(data) as unknown as ExpandedDataWithBlock;
 };
+
 const dataManager = new EditingDataManager(fetchPageList, fetchPage);
 
 export default function Index() {

--- a/noco-lib/editing/component-registry-context.ts
+++ b/noco-lib/editing/component-registry-context.ts
@@ -1,0 +1,16 @@
+import React from "react";
+import { ComponentRegistry } from "./component-registry";
+
+export const componentRegistryContext = React.createContext<
+  ComponentRegistry | undefined
+>(undefined);
+
+export const useComponentRegistry = () => {
+  const registry = React.useContext(componentRegistryContext);
+  if (!registry) {
+    throw new Error(
+      "useComponentRegistry must be used within a ComponentRegistryProvider"
+    );
+  }
+  return registry;
+};

--- a/noco-lib/editing/component-registry.ts
+++ b/noco-lib/editing/component-registry.ts
@@ -1,78 +1,70 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { NocoErrorViewFactory } from "./noco-error-view";
-
-export type ComponentRegistryMap = Map<
-  string,
-  () => Promise<React.ComponentType<any>>
->;
+import { type ErrorView } from "./noco-error-view";
+export type ComponentDriver = {
+  id: string;
+  type: string;
+  loadComponent: () => Promise<React.ComponentType<any>>;
+  componentPromise?: Promise<React.ComponentType<any>>;
+  component?: React.ComponentType<any>;
+  LoadSchema?: () => Promise<unknown>;
+  schemaPromise?: Promise<unknown>;
+  schema?: unknown;
+};
 
 export class ComponentRegistry {
-  private registry: Map<string, ComponentRegistryMap> = new Map();
-  private loadedComponents: Map<
-    string,
-    Map<string, React.ComponentType<unknown>>
-  > = new Map();
-  private loadingComponents: Map<
-    string,
-    Map<string, Promise<React.ComponentType<unknown>>>
-  > = new Map();
-
-  constructor(
-    public ErrorView: React.ComponentType<{ message: string }>,
-    public LoadingView: React.ComponentType<{
-      message: string;
-    }>
-  ) {}
-  addRegistry(key: string, registry: ComponentRegistryMap): void {
-    this.registry.set(key, registry);
+  byId = new Map<string, ComponentDriver>();
+  byType = new Map<string, Map<string, ComponentDriver>>();
+  register(componentDriver: ComponentDriver) {
+    this.validateRegistration(componentDriver);
+    this.byId.set(componentDriver.id, componentDriver);
+    this.indexByType(componentDriver);
   }
-  getComponentIfLoaded(
-    category: string,
-    name: string
-  ): React.ComponentType<any> | undefined {
-    return this.loadedComponents.get(category)?.get(name);
+  registerAll(componentDrivers: ComponentDriver[]) {
+    componentDrivers.forEach((componentDriver) =>
+      this.register(componentDriver)
+    );
+  }
+  getDriverById(id: string) {
+    const componentDriver = this.byId.get(id);
+    if (!componentDriver) {
+      throw new Error(`Component with id ${id} not found`);
+    }
+    return componentDriver;
+  }
+  getComponentById(id: string) {
+    return this.byId.get(id)?.component;
+  }
+  async loadComponentById(id: string) {
+    const componentDriver = this.getDriverById(id);
+    if (componentDriver.component) {
+      return componentDriver.component;
+    }
+    if (!componentDriver.componentPromise) {
+      componentDriver.componentPromise = componentDriver.loadComponent();
+    }
+    return await componentDriver.componentPromise;
+  }
+  getErrorView() {
+    const comp = this.getDriverById("NocoErrorView")?.component;
+    if (!comp) {
+      throw new Error("NocoErrorView is not found");
+    }
+    return comp as typeof ErrorView;
+  }
+  private indexByType(componentDriver: ComponentDriver) {
+    if (!this.byType.has(componentDriver.type)) {
+      this.byType.set(componentDriver.type, new Map());
+    }
+    this.byType
+      .get(componentDriver.type)!
+      .set(componentDriver.id, componentDriver);
   }
 
-  async loadComponent(
-    category: string,
-    name: string
-  ): Promise<React.ComponentType<unknown>> {
-    if (
-      this.loadedComponents.has(category) &&
-      this.loadedComponents.get(category)!.has(name)
-    ) {
-      return this.loadedComponents.get(category)!.get(name)!;
-    }
-    if (
-      this.loadingComponents.has(category) &&
-      this.loadingComponents.get(category)!.has(name)
-    ) {
-      return this.loadingComponents.get(category)!.get(name)!;
-    }
-    const registry = this.registry.get(category);
-    if (!registry) {
-      // eslint-disable-next-line no-console
-      console.warn(`No registry found for category ${category}`);
-      return NocoErrorViewFactory(category, name, false);
-    }
-    const componentPromise = registry.get(name)?.();
-    if (!componentPromise) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `No component found for category ${category} and name ${name}`
+  private validateRegistration(componentDriver: ComponentDriver) {
+    if (this.byId.has(componentDriver.id)) {
+      throw new Error(
+        `Component with id ${componentDriver.id} already registered`
       );
-      return NocoErrorViewFactory(category, name, true);
     }
-    if (!this.loadingComponents.has(category)) {
-      this.loadingComponents.set(category, new Map());
-    }
-    this.loadingComponents.get(category)!.set(name, componentPromise);
-    const component = await componentPromise;
-    this.loadingComponents.get(category)!.delete(name);
-    if (!this.loadedComponents.has(category)) {
-      this.loadedComponents.set(category, new Map());
-    }
-    this.loadedComponents.get(category)?.set(name, component);
-    return component;
   }
 }

--- a/noco-lib/editing/component-registry.ts
+++ b/noco-lib/editing/component-registry.ts
@@ -4,11 +4,12 @@ export type ComponentDriver = {
   id: string;
   type: string;
   loadComponent: () => Promise<React.ComponentType<any>>;
-  componentPromise?: Promise<React.ComponentType<any>>;
-  component?: React.ComponentType<any>;
   LoadSchema?: () => Promise<unknown>;
-  schemaPromise?: Promise<unknown>;
+  component?: React.ComponentType<any>;
   schema?: unknown;
+  componentPromise?: Promise<React.ComponentType<any>>;
+  schemaPromise?: Promise<unknown>;
+  componentLoadError?: unknown;
 };
 
 export class ComponentRegistry {
@@ -42,7 +43,12 @@ export class ComponentRegistry {
     if (!componentDriver.componentPromise) {
       componentDriver.componentPromise = componentDriver.loadComponent();
     }
-    return await componentDriver.componentPromise;
+    try {
+      return await componentDriver.componentPromise;
+    } catch (e) {
+      componentDriver.componentLoadError = e;
+      throw e;
+    }
   }
   getErrorView() {
     const comp = this.getDriverById("NocoErrorView")?.component;

--- a/noco-lib/editing/noco-edit-view.tsx
+++ b/noco-lib/editing/noco-edit-view.tsx
@@ -8,7 +8,6 @@ import {
 import { usePage } from "./use-page";
 import { useComponentRegistry } from "./component-registry-context";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useNocoEditView = <U,>(
   toJsx: <P>(
     compType: React.ComponentType<P>,
@@ -22,7 +21,7 @@ export const useNocoEditView = <U,>(
   const componentRegistry = useComponentRegistry();
 
   const deserializedPage = useMemo(() => {
-    const deps = new Set(getDeserialieDependecies(page));
+    const deps = new Set(getDeserializeDependencies(page));
     for (const dep of deps) {
       if (!componentRegistry.getComponentById(dep)) {
         componentRegistry.loadComponentById(dep).then(onComponentLoaded);
@@ -58,7 +57,7 @@ export const useNocoEditView = <U,>(
   return deserializedPage as JSX.Element | null;
 };
 
-function getDeserialieDependecies(data: ExpandedData): string[] {
+function getDeserializeDependencies(data: ExpandedData): string[] {
   if (!data) {
     return [];
   }
@@ -66,7 +65,7 @@ function getDeserialieDependecies(data: ExpandedData): string[] {
     return [
       data.value.__noco__type__.value,
       ...Object.values(data.value.props.value).flatMap(
-        getDeserialieDependecies
+        getDeserializeDependencies
       ),
     ];
   }
@@ -74,13 +73,14 @@ function getDeserialieDependecies(data: ExpandedData): string[] {
     return [];
   }
   if (Array.isArray(data.value)) {
-    return data.value.flatMap(getDeserialieDependecies);
+    return data.value.flatMap(getDeserializeDependencies);
   }
   if (typeof data.value === "object") {
-    return Object.values(data.value).flatMap(getDeserialieDependecies);
+    return Object.values(data.value).flatMap(getDeserializeDependencies);
   }
   return [];
 }
+
 function mapToEditView(
   data: ExpandedData,
   deserialize: (

--- a/noco-lib/editing/noco-error-view.tsx
+++ b/noco-lib/editing/noco-error-view.tsx
@@ -1,35 +1,19 @@
-import React from "react";
+import { ComponentDriver } from "./component-registry";
 
-export const cachedComponentMap = new Map<
-  string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Map<string, React.ComponentType<any>>
->();
-export const NocoErrorViewFactory = (
-  categoryName: string,
-  componentName: string,
-  categoryFound: boolean
-) => {
-  if (cachedComponentMap.has(categoryName)) {
-    const categoryMap = cachedComponentMap.get(categoryName)!;
-    if (categoryMap.has(componentName)) {
-      return categoryMap.get(componentName)!;
-    }
-  }
-  const errorView = () => {
-    return (
-      <div>
-        <h1>
-          {categoryFound
-            ? `Component ${componentName} not found in category ${categoryName}`
-            : `Category ${categoryName} not found`}
-        </h1>
-      </div>
-    );
-  };
-  if (!cachedComponentMap.has(categoryName)) {
-    cachedComponentMap.set(categoryName, new Map());
-  }
-  cachedComponentMap.get(categoryName)!.set(componentName, errorView);
-  return errorView;
-};
+export function ErrorView({ message }: { message: string }) {
+  return (
+    <div>
+      <h1>{message}</h1>
+    </div>
+  );
+}
+
+export const systemErrors: ComponentDriver[] = [
+  {
+    id: "NocoErrorView",
+    type: "#noco-system-component",
+    loadComponent: async () => ErrorView,
+    LoadSchema: async () => {},
+    component: ErrorView,
+  },
+];

--- a/noco-lib/editing/use-component.ts
+++ b/noco-lib/editing/use-component.ts
@@ -1,33 +1,25 @@
 import React, { useCallback } from "react";
-import { ComponentRegistry } from "./component-registry";
-import { NocoErrorViewFactory } from "./noco-error-view";
 import { useAsync } from "./use-async";
+import { useComponentRegistry } from "./component-registry-context";
 
-export const componentRegistryContext = React.createContext<ComponentRegistry>(
-  new ComponentRegistry(
-    NocoErrorViewFactory("ComponentRegistry", "Loading", true),
-    NocoErrorViewFactory("ComponentRegistry", "Loading", true)
-  )
-);
+export const useComponent = (id: string): React.ComponentType | undefined => {
+  const registry = useComponentRegistry();
 
-export const useComponent = (
-  categoryName: string,
-  name?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): React.ComponentType<any> | null => {
-  const registry = React.useContext(componentRegistryContext);
+  const load = useCallback(async () => {
+    const loadedComponent = registry.getComponentById(id);
+    if (loadedComponent) {
+      return loadedComponent;
+    }
+    try {
+      return registry.loadComponentById(id);
+    } catch (e) {
+      const LoadingError = () =>
+        React.createElement(registry.getErrorView(), {
+          message: String(e),
+        });
+      return LoadingError;
+    }
+  }, [id, registry]);
 
-  return useAsync(
-    useCallback(() => {
-      const loadedComponent =
-        name && registry.getComponentIfLoaded(categoryName, name);
-      if (loadedComponent) {
-        return loadedComponent;
-      }
-      if (!name) {
-        return NocoErrorViewFactory(categoryName, "Loading", true);
-      }
-      return registry.loadComponent(categoryName, name);
-    }, [categoryName, name, registry])
-  );
+  return useAsync(load);
 };

--- a/noco-lib/universal/expander.ts
+++ b/noco-lib/universal/expander.ts
@@ -1,12 +1,12 @@
 import {
-  type ExpandedDataValueContstraints,
+  type ExpandedDataValueConstraints,
   type ExpandedData,
   type ToExpandedData,
   generateGUID,
 } from "./types";
 
-export function expandDataWithNewIds<T extends ExpandedDataValueContstraints>(
-  data: ExpandedDataValueContstraints
+export function expandDataWithNewIds<T extends ExpandedDataValueConstraints>(
+  data: ExpandedDataValueConstraints
 ): ToExpandedData<T> {
   if (data === null || data === undefined) {
     return {

--- a/noco-lib/universal/types.ts
+++ b/noco-lib/universal/types.ts
@@ -13,7 +13,7 @@ export const generateGUID = <T extends DataChangeCategory>(
 
 export type DataChangeCategory = "primitive" | "object" | "array";
 
-export type ExpandedDataValueContstraints =
+export type ExpandedDataValueConstraints =
   | string
   | number
   | boolean
@@ -24,7 +24,7 @@ export type ExpandedDataValueContstraints =
   | Record<never, never>;
 
 export interface ExpandedData<
-  V extends ExpandedDataValueContstraints = ExpandedDataValueContstraints
+  V extends ExpandedDataValueConstraints = ExpandedDataValueConstraints
 > {
   value: V;
   id: GUID;

--- a/src/_codux/boards/noco-edit-view/noco-pages.board.tsx
+++ b/src/_codux/boards/noco-edit-view/noco-pages.board.tsx
@@ -2,7 +2,7 @@ import { createBoard } from "@wixc3/react-board";
 import { useNocoEditView } from "../../../../noco-lib/editing/noco-edit-view";
 import { ComponentRegistry } from "noco-lib/editing/component-registry";
 import { pageTemplates } from "~/noco/page-templates";
-import { sectionMap } from "~/noco/sections";
+import { sections } from "~/noco/sections";
 import { expandDataWithNewIds } from "noco-lib/universal/expander";
 import pageList from "../../../../data-mocks/page-list.json";
 import homeData from "../../../../data-mocks/home.json";
@@ -11,17 +11,15 @@ import {
   EditingDataManager,
   editingDataProviderContext,
 } from "noco-lib/editing/editing-data-manager";
-import { componentRegistryContext } from "noco-lib/editing/use-component";
-import { NocoErrorViewFactory } from "noco-lib/editing/noco-error-view";
-import { useCallback } from "react";
-import React from "react";
-const componentRegistry = new ComponentRegistry(
-  NocoErrorViewFactory("ComponentRegistry", "Loading", true),
-  NocoErrorViewFactory("ComponentRegistry", "Loading", true)
-);
+import { componentRegistryContext } from "noco-lib/editing/component-registry-context";
+import React, { useCallback } from "react";
+import { systemErrors } from "noco-lib/editing/noco-error-view";
 
-componentRegistry.addRegistry("pageTemplates", pageTemplates);
-componentRegistry.addRegistry("sections", sectionMap);
+const componentRegistry = new ComponentRegistry();
+componentRegistry.registerAll(systemErrors);
+componentRegistry.registerAll(pageTemplates);
+componentRegistry.registerAll(sections);
+
 const fetchPageList = async () => expandDataWithNewIds(pageList);
 const fetchPage = async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Since we are working progress here. 
This PR change the meaning of __noco_type__ to be an id. 
this id is saved in the document I think we should probably also add version and think a bit about mabye extend to be an object.
(the category still encoded there but no split is needed.)

the `useNocoEditView` should not relay on the registry returning an error compoent but move that logic into a LazyComponent which will be also a system comonent the same as the ErrorView. it will simplify the render page code

currently I might broke the rendering when loading is failed but soon to be fixed.
 